### PR TITLE
chore: update package versions to 9.2.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,9 +1,9 @@
 <Project>
   <ItemGroup>
-    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="9.1.0" />
-    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="9.1.0" />
-    <PackageVersion Include="Aspire.Hosting" Version="9.1.0" />
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.1.0"/>
+    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Hosting" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.2.0"/>
     <PackageVersion Include="AspNetCore.HealthChecks.Azure.Storage.Blobs" Version="9.0.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.Rabbitmq" Version="9.0.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.Redis" Version="9.0.0" />


### PR DESCRIPTION
Update Aspire.Hosting packages to version 9.2.0 to ensure 
compatibility with the latest features and improvements. This 
change enhances the overall stability and performance of the 
application.