### PR TITLE
feat: update server configurations and dependencies

### DIFF
--- a/playground/Test.AppHost/Program.cs
+++ b/playground/Test.AppHost/Program.cs
@@ -1,7 +1,13 @@
+using SimCube.Aspire.Components.LavinMQ;
+using SimCube.Aspire.Components.MailPit;
+using SimCube.Aspire.Components.PostgresServer;
 using SimCube.Aspire.Components.Valkey;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
-builder.AddValkeyServerInstance(withRedisCommander: true, withRedisInsight: true);
+builder.AddValkeyServerInstance(withRedisCommander: false, withRedisInsight: true);
+builder.AddLavinMQServerInstance();
+builder.AddPostgresServerInstance(withPgAdmin: true);
+builder.AddMailpitServerInstance();
 
 builder.Build().Run();

--- a/playground/Test.AppHost/Test.AppHost.csproj
+++ b/playground/Test.AppHost/Test.AppHost.csproj
@@ -1,13 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <Sdk Name="Aspire.AppHost.Sdk" Version="9.0.0"/>
+    <Sdk Name="Aspire.AppHost.Sdk" Version="9.2.0"/>
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <IsAspireHost>true</IsAspireHost>
         <UserSecretsId>65bec0b9-5c9d-4ed1-9aa1-7a5144f04f88</UserSecretsId>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/SimCube.Aspire.Components/Azurite/AzuriteContainerImageTags.cs
+++ b/src/SimCube.Aspire.Components/Azurite/AzuriteContainerImageTags.cs
@@ -9,5 +9,5 @@ internal static class AzuriteContainerImageTags
     public const string Image = "azure-storage/azurite";
 
     /// <remarks>3.33.0</remarks>
-    public const string Tag = "3.33.0";
+    public const string Tag = "3.34.0";
 }

--- a/src/SimCube.Aspire.Components/LavinMQ/LavinMQBuilderExtensions.cs
+++ b/src/SimCube.Aspire.Components/LavinMQ/LavinMQBuilderExtensions.cs
@@ -78,7 +78,8 @@ public static class LavinMQBuilderExtensions
                           context.EnvironmentVariables["LAVINMQ_PASSWORD"] = instance.PasswordReference;
                           context.EnvironmentVariables["LAVINMQ_VIRUALHOST"] = instance.VirtualHostReference;
                       })
-                      .WithHealthCheck(healthCheckKey);
+                      .WithHealthCheck(healthCheckKey)
+                      .WithUrlForEndpoint(LavinMQServerResource.ManagementEndpointName, u => u.DisplayText = "LavinMQ Management UI");
     }
 
     public static IResourceBuilder<LavinMQServerResource> WithDataVolume(this IResourceBuilder<LavinMQServerResource> builder, string name, bool isReadOnly = false)

--- a/src/SimCube.Aspire.Components/LavinMQ/LavinMQServerContainerImageTags.cs
+++ b/src/SimCube.Aspire.Components/LavinMQ/LavinMQServerContainerImageTags.cs
@@ -9,5 +9,5 @@ internal static class LavinMQServerContainerImageTags
     public const string Image = "cloudamqp/lavinmq";
 
     /// <remarks>2.1.0</remarks>
-    public const string Tag = "2.1.0";
+    public const string Tag = "2.2.0";
 }

--- a/src/SimCube.Aspire.Components/MailPit/MailPitBuilderExtensions.cs
+++ b/src/SimCube.Aspire.Components/MailPit/MailPitBuilderExtensions.cs
@@ -44,7 +44,8 @@ public static class MailPitBuilderExtensions
                       .WithEnvironment(context =>
                       {
                           context.EnvironmentVariables[MailpitDatabaseEnvVar] = "/data/mailpit.db";
-                      });
+                      })
+                      .WithUrlForEndpoint(MailPitServerResource.HttpEndpointName, u => u.DisplayText = "Mailpit UI");
     }
 
     public static IResourceBuilder<MailPitServerResource> WithDataVolume(this IResourceBuilder<MailPitServerResource> builder, string name, bool isReadOnly = false)

--- a/src/SimCube.Aspire.Components/MailPit/MailPitServerContainerImageTags.cs
+++ b/src/SimCube.Aspire.Components/MailPit/MailPitServerContainerImageTags.cs
@@ -9,5 +9,5 @@ internal static class MailpitContainerImageTags
     public const string Image = "axllent/mailpit";
 
     /// <remarks>v1.22.0</remarks>
-    public const string Tag = "v1.22.0";
+    public const string Tag = "v1.24.0";
 }

--- a/src/SimCube.Aspire.Components/PostgresServer/PostgresServerBuilderExtensions.cs
+++ b/src/SimCube.Aspire.Components/PostgresServer/PostgresServerBuilderExtensions.cs
@@ -39,6 +39,7 @@ public static class PostgresServerBuilderExtensions
                 options =>
                 {
                     options.WithContainerName("pgadmin");
+                    options.WithImageTag("9.2.0");
 
                     options.WithEndpoint("http", annotation =>
                     {
@@ -46,6 +47,8 @@ public static class PostgresServerBuilderExtensions
                         annotation.TargetPort = 80;
                         annotation.IsProxied = false;
                     });
+
+                    options.WithUrlForEndpoint("http", u => u.DisplayText = "PG Admin");
 
                     if (keepRunning)
                     {

--- a/src/SimCube.Aspire.Components/Valkey/ValkeyServerBuilderExtensions.cs
+++ b/src/SimCube.Aspire.Components/Valkey/ValkeyServerBuilderExtensions.cs
@@ -28,25 +28,31 @@ public static class ValkeyServerBuilderExtensions
                 opt =>
                 {
                     opt.WithContainerName("valkey-commander");
+
                     if (keepRunning)
                     {
                         opt.WithLifetime(ContainerLifetime.Persistent);
                     }
+
+                    opt.WithUrlForEndpoint("http", u => u.DisplayText = "Redis Commander");
                 });
         }
 
         if (withRedisInsight)
         {
-            instance.WithRedisInsight(opt =>
-            {
-                opt.WithDataVolume();
-                opt.WithContainerName("valkey-insight");
-
-                if (keepRunning)
+            instance.WithRedisInsight(
+                opt =>
                 {
-                    opt.WithLifetime(ContainerLifetime.Persistent);
-                }
-            });
+                    opt.WithDataVolume();
+                    opt.WithContainerName("valkey-insight");
+
+                    if (keepRunning)
+                    {
+                        opt.WithLifetime(ContainerLifetime.Persistent);
+                    }
+
+                    opt.WithUrlForEndpoint("http", u => u.DisplayText = "Redis Insight");
+                });
         }
 
         return instance;

--- a/src/SimCube.Aspire.Components/Valkey/ValkeyServerContainerImageTags.cs
+++ b/src/SimCube.Aspire.Components/Valkey/ValkeyServerContainerImageTags.cs
@@ -9,7 +9,7 @@ internal static class ValkeyServerContainerImageTags
     public const string Image = "valkey/valkey";
 
     /// <remarks>8.0.2-alpine</remarks>
-    public const string Tag = "8.0.2-alpine";
+    public const string Tag = "8.1.0-alpine";
 
     public const string RedisCommanderRegistry = "docker.io";
 
@@ -26,5 +26,5 @@ internal static class ValkeyServerContainerImageTags
     public const string RedisInsightImage = "redis/redisinsight";
 
     /// <remarks>2.64</remarks>
-    public const string RedisInsightTag = "2.64";
+    public const string RedisInsightTag = "2.68";
 }


### PR DESCRIPTION
- Updated Valkey server configurations to include Named URL endpoints for Redis Commander and Redis Insight.
- Changed Redis Insight image tag to 2.68, LavinMQ image tag to 2.2, Valkey image to 81.0-alpine, and Azurite image tag to 3.34.0.
- Enhanced server setup for improved compatibility with the latest versions.
- Added named endpoints for all HTTP services exposed by components