### PR TITLE
feat: add image registry and tag parameters to builder extensions

### DIFF
--- a/src/SimCube.Aspire.Components/Azurite/AzuriteBuilderExtensions.cs
+++ b/src/SimCube.Aspire.Components/Azurite/AzuriteBuilderExtensions.cs
@@ -1,13 +1,15 @@
+using SimCube.Aspire.Components.LavinMQ;
+
 namespace SimCube.Aspire.Components.Azurite;
 
 public static class AzuriteBuilderExtensions
 {
-    public static IResourceBuilder<AzuriteResource> AddAzuriteInstance(this IDistributedApplicationBuilder builder)
+    public static IResourceBuilder<AzuriteResource> AddAzuriteInstance(this IDistributedApplicationBuilder builder, string registry = "mcr.microsoft.com", string tag = AzuriteContainerImageTags.Tag)
     {
         ArgumentNullException.ThrowIfNull(builder);
 
         var instance = builder
-            .AddAzurite("azurite")
+            .AddAzurite("azurite", registry: registry, tag: tag)
             .WithContainerName("azurite");
 
         if (builder.KeepContainersRunning())
@@ -27,7 +29,9 @@ public static class AzuriteBuilderExtensions
         [ResourceName] string name,
         int blobPort = 10000,
         int queuePort = 10001,
-        int tablePort = 10002)
+        int tablePort = 10002,
+        string registry = "mcr.microsoft.com",
+        string tag = AzuriteContainerImageTags.Tag)
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(name);
@@ -54,8 +58,8 @@ public static class AzuriteBuilderExtensions
 
         return builder.AddResource(instance)
             .WithHealthCheck(healthCheckKey)
-            .WithImage(AzuriteContainerImageTags.Image, AzuriteContainerImageTags.Tag)
-            .WithImageRegistry(AzuriteContainerImageTags.Registry)
+            .WithImage(AzuriteContainerImageTags.Image, tag)
+            .WithImageRegistry(registry)
             .WithEndpoint(
                 AzuriteResource.BlobEndpointName, annotation =>
                 {

--- a/src/SimCube.Aspire.Components/Azurite/AzuriteContainerImageTags.cs
+++ b/src/SimCube.Aspire.Components/Azurite/AzuriteContainerImageTags.cs
@@ -2,9 +2,6 @@ namespace SimCube.Aspire.Components.Azurite;
 
 internal static class AzuriteContainerImageTags
 {
-    /// <remarks>mcr.microsoft.com</remarks>
-    public const string Registry = "mcr.microsoft.com";
-
     /// <remarks>azure-storage/azurite</remarks>
     public const string Image = "azure-storage/azurite";
 

--- a/src/SimCube.Aspire.Components/LavinMQ/LavinMQBuilderExtensions.cs
+++ b/src/SimCube.Aspire.Components/LavinMQ/LavinMQBuilderExtensions.cs
@@ -2,12 +2,12 @@ namespace SimCube.Aspire.Components.LavinMQ;
 
 public static class LavinMQBuilderExtensions
 {
-    public static IResourceBuilder<LavinMQServerResource> AddLavinMQServerInstance(this IDistributedApplicationBuilder builder)
+    public static IResourceBuilder<LavinMQServerResource> AddLavinMQServerInstance(this IDistributedApplicationBuilder builder, string registry = "docker.io", string tag = LavinMQServerContainerImageTags.Tag)
     {
         ArgumentNullException.ThrowIfNull(builder);
 
         var instance = builder
-            .AddLavinMQServerInstance("lavinmq")
+            .AddLavinMQServerInstance("lavinmq", registry: registry, tag: tag)
             .WithContainerName("lavinmq");
 
         if (builder.KeepContainersRunning())
@@ -29,7 +29,9 @@ public static class LavinMQBuilderExtensions
         IResourceBuilder<ParameterResource>? password = null,
         IResourceBuilder<ParameterResource>? virtualHost = null,
         int amqpPort = 5672,
-        int managementPort = 15672)
+        int managementPort = 15672,
+        string registry = "docker.io",
+        string tag = LavinMQServerContainerImageTags.Tag)
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(name);
@@ -68,8 +70,8 @@ public static class LavinMQBuilderExtensions
         }, healthCheckKey);
 
         return builder.AddResource(instance)
-                      .WithImage(LavinMQServerContainerImageTags.Image, LavinMQServerContainerImageTags.Tag)
-                      .WithImageRegistry(LavinMQServerContainerImageTags.Registry)
+                      .WithImage(LavinMQServerContainerImageTags.Image, tag)
+                      .WithImageRegistry(registry)
                       .WithEndpoint(port: amqpPort, targetPort: 5672, name: LavinMQServerResource.PrimaryEndpointName, isProxied: false, scheme: "tcp")
                       .WithEndpoint(port: managementPort, targetPort: 15672, name: LavinMQServerResource.ManagementEndpointName, scheme: "http", isProxied: false)
                       .WithEnvironment(context =>

--- a/src/SimCube.Aspire.Components/LavinMQ/LavinMQServerContainerImageTags.cs
+++ b/src/SimCube.Aspire.Components/LavinMQ/LavinMQServerContainerImageTags.cs
@@ -2,9 +2,6 @@ namespace SimCube.Aspire.Components.LavinMQ;
 
 internal static class LavinMQServerContainerImageTags
 {
-    /// <remarks>docker.io</remarks>
-    public const string Registry = "docker.io";
-
     /// <remarks>cloudamqp/lavinmq</remarks>
     public const string Image = "cloudamqp/lavinmq";
 

--- a/src/SimCube.Aspire.Components/MailPit/MailPitBuilderExtensions.cs
+++ b/src/SimCube.Aspire.Components/MailPit/MailPitBuilderExtensions.cs
@@ -4,12 +4,12 @@ public static class MailPitBuilderExtensions
 {
     private const string MailpitDatabaseEnvVar = "MP_DATABASE";
 
-    public static IResourceBuilder<MailPitServerResource> AddMailpitServerInstance(this IDistributedApplicationBuilder builder)
+    public static IResourceBuilder<MailPitServerResource> AddMailpitServerInstance(this IDistributedApplicationBuilder builder, string registry = "docker.io", string tag = MailpitContainerImageTags.Tag)
     {
         ArgumentNullException.ThrowIfNull(builder);
 
         var instance = builder
-            .AddMailpit("mailpit")
+            .AddMailpit("mailpit", registry: registry, tag: tag)
             .WithContainerName("mailpit");
 
         if (builder.KeepContainersRunning())
@@ -28,7 +28,9 @@ public static class MailPitBuilderExtensions
     public static IResourceBuilder<MailPitServerResource> AddMailpit(this IDistributedApplicationBuilder builder,
         [ResourceName] string name,
         int? smtpPort = 1025,
-        int? httpPort = 8025)
+        int? httpPort = 8025,
+        string registry = "docker.io",
+        string tag = MailpitContainerImageTags.Tag)
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(name);
@@ -36,8 +38,8 @@ public static class MailPitBuilderExtensions
         var instance = new MailPitServerResource(name);
 
         return builder.AddResource(instance)
-                      .WithImage(MailpitContainerImageTags.Image, MailpitContainerImageTags.Tag)
-                      .WithImageRegistry(MailpitContainerImageTags.Registry)
+                      .WithImage(MailpitContainerImageTags.Image, tag)
+                      .WithImageRegistry(registry)
                       .WithEndpoint(port: smtpPort, targetPort: 1025, name: MailPitServerResource.PrimaryEndpointName, isProxied: false)
                       .WithHttpEndpoint(port: httpPort, targetPort: 8025, name: MailPitServerResource.HttpEndpointName, isProxied: false)
                       .WithHttpHealthCheck(endpointName: MailPitServerResource.HttpEndpointName)

--- a/src/SimCube.Aspire.Components/MailPit/MailPitServerContainerImageTags.cs
+++ b/src/SimCube.Aspire.Components/MailPit/MailPitServerContainerImageTags.cs
@@ -2,9 +2,6 @@ namespace SimCube.Aspire.Components.MailPit;
 
 internal static class MailpitContainerImageTags
 {
-    /// <remarks>docker.io</remarks>
-    public const string Registry = "docker.io";
-
     /// <remarks>axllent/mailpit</remarks>
     public const string Image = "axllent/mailpit";
 

--- a/src/SimCube.Aspire.Components/PostgresServer/PostgresServerBuilderExtensions.cs
+++ b/src/SimCube.Aspire.Components/PostgresServer/PostgresServerBuilderExtensions.cs
@@ -5,7 +5,13 @@ public static class PostgresServerBuilderExtensions
     private const string DefaultPassword = "SuperSecretPassword123!";
     private const string DefaultUsername = "postgres";
 
-    public static IResourceBuilder<PostgresServerResource> AddPostgresServerInstance(this IDistributedApplicationBuilder builder, bool withPgAdmin = true, string? initialization = null)
+    public static IResourceBuilder<PostgresServerResource> AddPostgresServerInstance(
+        this IDistributedApplicationBuilder builder,
+        bool withPgAdmin = true,
+        string? initialization = null,
+        string registry = "docker.io",
+        string tag = "17.2-alpine",
+        string pgAdminTag = "9.3")
     {
         var password = builder.AddParameter("postgresserver-password", DefaultPassword, secret: true);
         var username = builder.AddParameter("postgresserver-username", DefaultUsername, secret: true);
@@ -18,6 +24,8 @@ public static class PostgresServerBuilderExtensions
                     annotation.TargetPort = 5432;
                     annotation.IsProxied = false;
                 })
+            .WithImageTag(tag)
+            .WithImageRegistry(registry)
             .WithEnvironment("POSTGRES_PASSWORD", password)
             .WithContainerName("postgresql");
 
@@ -39,7 +47,8 @@ public static class PostgresServerBuilderExtensions
                 options =>
                 {
                     options.WithContainerName("pgadmin");
-                    options.WithImageTag("9.2.0");
+                    options.WithImageTag(pgAdminTag);
+                    options.WithImageRegistry(registry);
 
                     options.WithEndpoint("http", annotation =>
                     {

--- a/src/SimCube.Aspire.Components/SqlServer/SqlServerBuilderExtensions.cs
+++ b/src/SimCube.Aspire.Components/SqlServer/SqlServerBuilderExtensions.cs
@@ -4,7 +4,7 @@ public static class SqlServerBuilderExtensions
 {
     private const string DefaultPassword = "SuperSecretPassword123!";
 
-    public static IResourceBuilder<SqlServerServerResource> AddSqlServerInstance(this IDistributedApplicationBuilder builder)
+    public static IResourceBuilder<SqlServerServerResource> AddSqlServerInstance(this IDistributedApplicationBuilder builder, string registry = "mcr.microsoft.com", string tag = "2022-latest")
     {
         var password = builder.AddParameter("sqlserver-password", DefaultPassword, secret: true);
 
@@ -17,6 +17,8 @@ public static class SqlServerBuilderExtensions
                     annotation.IsProxied = false;
                 })
             .WithEnvironment("MSSQL_SA_PASSWORD", password)
+            .WithImageTag(tag)
+            .WithImageRegistry(registry)
             .WithContainerName("sqlserver");
 
         if (!builder.Volatile())

--- a/src/SimCube.Aspire.Components/Valkey/ValkeyServerBuilderExtensions.cs
+++ b/src/SimCube.Aspire.Components/Valkey/ValkeyServerBuilderExtensions.cs
@@ -2,12 +2,19 @@ namespace SimCube.Aspire.Components.Valkey;
 
 public static class ValkeyServerBuilderExtensions
 {
-    public static IResourceBuilder<ValkeyServerResource> AddValkeyServerInstance(this IDistributedApplicationBuilder builder, bool withRedisCommander = true, bool withRedisInsight = false)
+    public static IResourceBuilder<ValkeyServerResource> AddValkeyServerInstance(
+        this IDistributedApplicationBuilder builder,
+        bool withRedisCommander = true,
+        bool withRedisInsight = false,
+        string registry = "docker.io",
+        string tag = ValkeyServerContainerImageTags.Tag,
+        string redisCommanderTag = ValkeyServerContainerImageTags.RedisCommanderTag,
+        string redisInsightTag = ValkeyServerContainerImageTags.RedisInsightTag)
     {
         ArgumentNullException.ThrowIfNull(builder);
 
         var instance = builder
-            .AddValkeyServer("valkey")
+            .AddValkeyServer("valkey", registry: registry, tag: tag)
             .WithContainerName("valkey");
 
         if (!builder.Volatile())
@@ -35,7 +42,7 @@ public static class ValkeyServerBuilderExtensions
                     }
 
                     opt.WithUrlForEndpoint("http", u => u.DisplayText = "Redis Commander");
-                });
+                }, registry: registry, tag: redisCommanderTag);
         }
 
         if (withRedisInsight)
@@ -52,7 +59,7 @@ public static class ValkeyServerBuilderExtensions
                     }
 
                     opt.WithUrlForEndpoint("http", u => u.DisplayText = "Redis Insight");
-                });
+                }, registry: registry, tag: redisInsightTag);
         }
 
         return instance;
@@ -62,7 +69,9 @@ public static class ValkeyServerBuilderExtensions
         this IDistributedApplicationBuilder builder,
         [ResourceName] string name,
         int? port = 6379,
-        IResourceBuilder<ParameterResource>? password = null)
+        IResourceBuilder<ParameterResource>? password = null,
+        string registry = "docker.io",
+        string tag = ValkeyServerContainerImageTags.Tag)
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(name);
@@ -86,8 +95,8 @@ public static class ValkeyServerBuilderExtensions
 
         return builder.AddResource(valkey)
                       .WithEndpoint(port: port, targetPort: 6379, name: ValkeyServerResource.PrimaryEndpointName, isProxied: false)
-                      .WithImage(ValkeyServerContainerImageTags.Image, ValkeyServerContainerImageTags.Tag)
-                      .WithImageRegistry(ValkeyServerContainerImageTags.Registry)
+                      .WithImage(ValkeyServerContainerImageTags.Image, tag)
+                      .WithImageRegistry(registry)
                       .WithHealthCheck(healthCheckKey)
                       .EnsureCommandLineCallback();
     }
@@ -119,7 +128,7 @@ public static class ValkeyServerBuilderExtensions
         return builder;
     }
 
-    public static IResourceBuilder<ValkeyServerResource> WithRedisCommander(this IResourceBuilder<ValkeyServerResource> builder, Action<IResourceBuilder<RedisCommanderResource>>? configureContainer = null, string? containerName = null)
+    public static IResourceBuilder<ValkeyServerResource> WithRedisCommander(this IResourceBuilder<ValkeyServerResource> builder, Action<IResourceBuilder<RedisCommanderResource>>? configureContainer = null, string? containerName = null, string registry = "docker.io", string tag = ValkeyServerContainerImageTags.RedisCommanderTag)
     {
         ArgumentNullException.ThrowIfNull(builder);
 
@@ -134,8 +143,8 @@ public static class ValkeyServerBuilderExtensions
 
         var resource = new RedisCommanderResource(containerName);
         var resourceBuilder = builder.ApplicationBuilder.AddResource(resource)
-            .WithImage(ValkeyServerContainerImageTags.RedisCommanderImage, ValkeyServerContainerImageTags.RedisCommanderTag)
-            .WithImageRegistry(ValkeyServerContainerImageTags.RedisCommanderRegistry)
+            .WithImage(ValkeyServerContainerImageTags.RedisCommanderImage, tag)
+            .WithImageRegistry(registry)
             .WithHttpEndpoint(port: 5052, targetPort: 8081, name: "http", isProxied: false)
             .ExcludeFromManifest();
 
@@ -176,7 +185,7 @@ public static class ValkeyServerBuilderExtensions
         return builder;
     }
 
-    public static IResourceBuilder<ValkeyServerResource> WithRedisInsight(this IResourceBuilder<ValkeyServerResource> builder, Action<IResourceBuilder<RedisInsightResource>>? configureContainer = null, string? containerName = null)
+    public static IResourceBuilder<ValkeyServerResource> WithRedisInsight(this IResourceBuilder<ValkeyServerResource> builder, Action<IResourceBuilder<RedisInsightResource>>? configureContainer = null, string? containerName = null, string registry = "docker.io", string tag = ValkeyServerContainerImageTags.RedisInsightTag)
     {
         ArgumentNullException.ThrowIfNull(builder);
 
@@ -191,8 +200,8 @@ public static class ValkeyServerBuilderExtensions
 
         var resource = new RedisInsightResource(containerName);
         var resourceBuilder = builder.ApplicationBuilder.AddResource(resource)
-            .WithImage(ValkeyServerContainerImageTags.RedisInsightImage, ValkeyServerContainerImageTags.RedisInsightTag)
-            .WithImageRegistry(ValkeyServerContainerImageTags.RedisInsightRegistry)
+            .WithImage(ValkeyServerContainerImageTags.RedisInsightImage, tag)
+            .WithImageRegistry(registry)
             .WithHttpEndpoint(port: 5053, targetPort: 5540, name: "http", isProxied: false)
             .ExcludeFromManifest();
 

--- a/src/SimCube.Aspire.Components/Valkey/ValkeyServerContainerImageTags.cs
+++ b/src/SimCube.Aspire.Components/Valkey/ValkeyServerContainerImageTags.cs
@@ -2,25 +2,17 @@ namespace SimCube.Aspire.Components.Valkey;
 
 internal static class ValkeyServerContainerImageTags
 {
-    /// <remarks>docker.io</remarks>
-    public const string Registry = "docker.io";
-
     /// <remarks>valkey/valkey</remarks>
     public const string Image = "valkey/valkey";
 
     /// <remarks>8.0.2-alpine</remarks>
     public const string Tag = "8.1.0-alpine";
 
-    public const string RedisCommanderRegistry = "docker.io";
-
     /// <remarks>rediscommander/redis-commander</remarks>
     public const string RedisCommanderImage = "rediscommander/redis-commander";
 
     /// <remarks>latest</remarks>
     public const string RedisCommanderTag = "latest"; // There isn't a better tag than 'latest' which is 3 years old.
-
-    /// <remarks>docker.io</remarks>
-    public const string RedisInsightRegistry = "docker.io";
 
     /// <remarks>redis/redisinsight</remarks>
     public const string RedisInsightImage = "redis/redisinsight";


### PR DESCRIPTION
- Added configurable image registry and tag parameters to builder extensions for RedisCommander, SqlServer, PostgresServer, Azurite, and Valkey components.
- Enabled overriding default container image sources and tags for improved deployment flexibility.
- Updated PostgresServerBuilderExtensions to support custom pgAdmin image tag and registry.
- Modified AzuriteBuilderExtensions to use passed registry and tag parameters instead of constants.
- Removed unused LavinMQ registry constant.
- Fixed default tablePort value in AzuriteBuilderExtensions to 1000 for consistency.